### PR TITLE
Organize palettes modal - swatch dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Huebism is a HSL color space exploration and palette creation tool featuring an 
 
 - **Interactive 3D Palette Cube**: Visualize colors dots in a 3D space where coordinates are map to *Hue*, *Saturation*, and *Lightness*.
 - **Adjustable Hue Range**: Sliders allow you to adjust the hue range so you can focus on specific colors.
-- **Color Selection**: Click on any dot to select its color and view detailed properties, including HSL, RGB, and Hex codes.
-- **Predefined Palettes**: Explore palettes sourced from Wikipedia colors, CSS named colors, Coolors, and more.
-- **Custom Palettes**: Create, save, and manage your own custom palettes. Selected palettes are serialized and saved in localStorage.
+- **Color Selection**: Click on any dot to select its color and view detailed properties, including HSL, RGB, and Hex code.
 - **Color Interpolation**: Interpolate between two neighboring colors with customizable easing functions for each HSL property.
+- **Predefined Palettes**: Explore palettes sourced from Wikipedia colors, CSS named colors, Coolors, and more.
+- **Custom Palettes**: Create and manage your own custom palettes. Your palettes are serialized and stored in your browser's localStorage.
+- *COMING SOON* - **Interoperability**: Import and export palettes in a variety of formats.
 
 
 ## Usage

--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@
 ### In Progress
 
 - [x] custom palettes overview modal
-- [ ] custom palettes editing
+- [x] custom palettes editing
 - [ ] custom palettes export
 - [ ] create custom palettes from various data
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,8 @@
 
 ### In Progress
 
-- [ ] custom palettes overview modal
+- [x] custom palettes overview modal
+- [ ] custom palettes editing
 - [ ] custom palettes export
 - [ ] create custom palettes from various data
 

--- a/components/modal.css
+++ b/components/modal.css
@@ -1,7 +1,7 @@
 dialog {
     position: relative;
-    width: 80%;
-    height: 80%;
+    width: 90%;
+    height: 90%;
     overflow: auto;
     padding: 1em;
     box-sizing: border-box;
@@ -31,4 +31,30 @@ dialog > .close {
     right: 0.5em;
     display: block;
     margin-left: auto;
+}
+
+
+/* Organize modal */
+.overview {
+    display: grid;
+    gap: 1em;
+}
+
+.org-wrapper {
+    padding: 1em;
+    border-radius: 1em;
+    border: 2px solid #808080;
+}
+
+.org-palette {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(16ch, 1fr));
+}
+
+.org-swatch {
+    padding: 10px;
+    overflow: hidden;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -40,6 +40,8 @@ dialog > .close {
     position: relative;
     display: grid;
     gap: 1em;
+
+    --drop-time: 250ms;
 }
 
 .org-wrapper {
@@ -80,6 +82,16 @@ dialog > .close {
     box-sizing: border-box;
 
     cursor: pointer;
+    
+    /*     */
+    animation: reveal linear var(--drop-time);
+    /* animation-delay: var(--drop-time); */
+    mask-image: radial-gradient(black 35%, transparent 75%);
+    mask-position: 50% 50%;
+    mask-repeat: no-repeat;
+    mask-clip: no-clip;
+    mask-size: 300% 300%;
+    /* */
 }
 
 .org-swatch:focus {
@@ -92,6 +104,18 @@ dialog > .close {
     left: 50%;
 
     border-radius: 5px;
+}
+
+@keyframes reveal {
+    from {
+        mask-size: 0% 0%;
+    }
+    50% {
+        mask-size: 0% 0%;
+    }
+    to {
+        mask-size: 300% 300%;
+    }
 }
 
 .org-swatch[contenteditable="true"] {
@@ -151,7 +175,7 @@ dialog > .close {
 }
 
 .bucket.unfocus {
-    animation: pour 350ms /* ease-out */ forwards;
+    animation: pour var(--drop-time) linear forwards;
 }
 
 .bucket.focus {
@@ -186,7 +210,7 @@ dialog > .close {
         opacity: 1;
         border-radius: var(--size);
         border-width: 3px;
-        filter: blur(0);
+        /* filter: blur(0); */
 
         width: var(--size);
         height: var(--size);
@@ -194,23 +218,24 @@ dialog > .close {
         left: var(--left);
     }
     35% {
-        opacity: 1;
-        border-radius: 0;
+        /* opacity: 1; */
+        /* border-radius: 5px; */
         border-width: 0;
-        filter: blur(0);
+        /* filter: blur(0); */
     }
     85% {
-        opacity: 0;
-    }
-    to {
-        opacity: 0;
-        border-radius: 0;
-        border-width: 0;
-        filter: blur(3px);
+        opacity: 1;
+        border-radius: 5px;
 
         width: var(--w);
         height: var(--h);
         top: var(--y);
         left: var(--x);
+    }
+    to {
+        opacity: 0;
+        /* border-radius: 5px; */
+        border-width: 0;
+        /* filter: blur(3px); */
     }
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -19,6 +19,7 @@ dialog::backdrop {
 /* TODO: remove defaults from dialog and explicitly style .modal */
 dialog > .modal {
     position: absolute;
+    overflow: hidden;
     inset: 0;
     height: fit-content;
     padding: 2rem;
@@ -37,7 +38,6 @@ dialog > .close {
 /* Organize modal */
 .overview {
     position: relative;
-    overflow: hidden;
     display: grid;
     gap: 1em;
 }
@@ -64,7 +64,7 @@ dialog > .close {
 
 .org-swatch {
     padding: 10px;
-    padding-left: 1em;
+    padding-left: 20px;
     position: relative;
     overflow: hidden;
     text-wrap: nowrap;
@@ -90,15 +90,39 @@ dialog > .close {
     cursor: text;
 }
 
+.org-swatch-placeholder {
+    padding: 10px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+
+    color: white;
+    outline: 3px dashed currentColor;
+    outline-offset: -3px;
+    
+    cursor: context-menu;
+}
+
+.org-swatch-placeholder::after {
+    content: '🌢';
+}
+
 .drag-handle {
     /* font-weight: bolder; */
     font-size: 150%;
     position: absolute;
-    top: 50%;
-    left: 0.25rem;
-    translate: 0 -50%;
+    top: 0;
+    left: 0;
+    width: 20px;
+    height: 100%;
+
+    display: grid;
+    place-items: center;
+
+    background-color: #80808080;
 
     cursor: grab;
+    user-select: none;
 }
 
 .bucket {

--- a/components/modal.css
+++ b/components/modal.css
@@ -107,7 +107,7 @@ dialog > .close {
     color: white;
     outline: 3px dashed currentColor;
     outline-offset: -3px;
-    
+
     cursor: context-menu;
 }
 
@@ -133,17 +133,84 @@ dialog > .close {
     user-select: none;
 }
 
+.drag-active :hover {
+    cursor: grabbing;
+}
+
 .bucket {
-    padding: 2em;
-    border: 2px solid white;
+    --size: 50px;
+    /* padding: 2em; */
+    border: solid white;
     translate: -50% -50%;
     position: absolute;
-    border-radius: 50%;
+    /* border-radius: 50%; */
 
     /* cursor: grabbing; */
     pointer-events: none;
+
 }
 
-.drag-active :hover {
-    cursor: grabbing;
+.bucket.unfocus {
+    animation: pour 350ms /* ease-out */ forwards;
+}
+
+.bucket.focus {
+    animation: ladle 250ms ease-in forwards;
+}
+
+/* bucket ladle/pour animations */
+@keyframes ladle {
+    from {
+        border-radius: 0;
+        border-width: 0;
+
+        width: var(--w);
+        height: var(--h);
+        top: var(--y);
+        left: var(--x);
+    }
+
+    to {
+        border-radius: var(--size);
+        border-width: 3px;
+
+        width: var(--size);
+        height: var(--size);
+        top: var(--top);
+        left: var(--left);
+    }
+}
+
+@keyframes pour {
+    from {
+        opacity: 1;
+        border-radius: var(--size);
+        border-width: 3px;
+        filter: blur(0);
+
+        width: var(--size);
+        height: var(--size);
+        top: var(--top);
+        left: var(--left);
+    }
+    35% {
+        opacity: 1;
+        border-radius: 0;
+        border-width: 0;
+        filter: blur(0);
+    }
+    85% {
+        opacity: 0;
+    }
+    to {
+        opacity: 0;
+        border-radius: 0;
+        border-width: 0;
+        filter: blur(3px);
+
+        width: var(--w);
+        height: var(--h);
+        top: var(--y);
+        left: var(--x);
+    }
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -69,7 +69,7 @@ dialog > .close {
 
 .drag-active .org-palette:hover {
     background-color: #ffffff33;
-    
+
     cursor: alias !important;
 }
 
@@ -78,7 +78,7 @@ dialog > .close {
     line-height: 1.5;
 
     padding: 10px;
-    padding-left: 20px;
+    padding-left: 25px;
     position: relative;
     overflow: hidden;
     text-wrap: nowrap;
@@ -86,16 +86,13 @@ dialog > .close {
     box-sizing: border-box;
 
     cursor: pointer;
-    
-    /*     */
+
     animation: reveal linear var(--drop-time);
-    /* animation-delay: var(--drop-time); */
     mask-image: radial-gradient(black 35%, transparent 75%);
     mask-position: 50% 50%;
     mask-repeat: no-repeat;
     mask-clip: no-clip;
     mask-size: 300% 300%;
-    /* */
 }
 
 .org-swatch:focus {
@@ -114,7 +111,7 @@ dialog > .close {
     from {
         mask-size: 0% 0%;
     }
-    50% {
+    65% {
         mask-size: 0% 0%;
     }
     to {
@@ -135,8 +132,6 @@ dialog > .close {
     color: white;
     outline: 3px dashed currentColor;
     outline-offset: -3px;
-
-    /* cursor: context-menu; */
 }
 
 .org-swatch-placeholder::after {
@@ -166,16 +161,12 @@ dialog > .close {
 }
 
 .bucket {
-    /* opacity: 0; */
     --size: 50px;
-    /* padding: 2em; */
     border: solid white;
     border-width: 0;
     translate: -50% -50%;
     position: absolute;
-    /* border-radius: 50%; */
 
-    /* cursor: grabbing; */
     pointer-events: none;
 }
 
@@ -199,7 +190,6 @@ dialog > .close {
         top: var(--y);
         left: var(--x);
     }
-
     to {
         opacity: 1;
         border-radius: var(--size);
@@ -217,7 +207,6 @@ dialog > .close {
         opacity: 1;
         border-radius: var(--size);
         border-width: 3px;
-        /* filter: blur(0); */
 
         width: var(--size);
         height: var(--size);
@@ -225,10 +214,7 @@ dialog > .close {
         left: var(--left);
     }
     35% {
-        /* opacity: 1; */
-        /* border-radius: 5px; */
         border-width: 0;
-        /* filter: blur(0); */
     }
     85% {
         opacity: 1;
@@ -241,8 +227,5 @@ dialog > .close {
     }
     to {
         opacity: 0;
-        /* border-radius: 5px; */
-        /* border-width: 0; */
-        /* filter: blur(3px); */
     }
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -60,9 +60,17 @@ dialog > .close {
 .org-palette {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(16ch, 1fr));
+    min-height: calc(20px + 1.5rem);
+}
+
+.drag-active .org-palette:hover {
+    background-color: #ffffff33;
 }
 
 .org-swatch {
+    font-size: 1rem;
+    line-height: 1.5;
+
     padding: 10px;
     padding-left: 20px;
     position: relative;
@@ -132,6 +140,10 @@ dialog > .close {
     position: absolute;
     border-radius: 50%;
 
-    cursor: grabbing;
+    /* cursor: grabbing; */
     pointer-events: none;
+}
+
+.drag-active :hover {
+    cursor: grabbing;
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -18,9 +18,11 @@ dialog::backdrop {
 
 /* TODO: remove defaults from dialog and explicitly style .modal */
 dialog > .modal {
+    box-sizing: border-box;
     position: absolute;
     overflow: hidden;
     inset: 0;
+    min-height: 100%;
     height: fit-content;
     padding: 2rem;
     background-color: hsl(0, 0%, var(--bg-value, 50%));
@@ -52,7 +54,7 @@ dialog > .close {
 
 .org-wrapper > p {
     margin-bottom: 0.5em;
-    cursor: pointer;
+    /* cursor: pointer; */
 }
 
 .org-wrapper > p[contenteditable="true"] {
@@ -67,6 +69,8 @@ dialog > .close {
 
 .drag-active .org-palette:hover {
     background-color: #ffffff33;
+    
+    cursor: alias !important;
 }
 
 .org-swatch {
@@ -132,7 +136,7 @@ dialog > .close {
     outline: 3px dashed currentColor;
     outline-offset: -3px;
 
-    cursor: context-menu;
+    /* cursor: context-menu; */
 }
 
 .org-swatch-placeholder::after {
@@ -157,21 +161,22 @@ dialog > .close {
     user-select: none;
 }
 
-.drag-active :hover {
-    cursor: grabbing;
+.drag-active:hover {
+    cursor: grabbing !important;
 }
 
 .bucket {
+    /* opacity: 0; */
     --size: 50px;
     /* padding: 2em; */
     border: solid white;
+    border-width: 0;
     translate: -50% -50%;
     position: absolute;
     /* border-radius: 50%; */
 
     /* cursor: grabbing; */
     pointer-events: none;
-
 }
 
 .bucket.unfocus {
@@ -185,6 +190,7 @@ dialog > .close {
 /* bucket ladle/pour animations */
 @keyframes ladle {
     from {
+        opacity: 1;
         border-radius: 0;
         border-width: 0;
 
@@ -195,6 +201,7 @@ dialog > .close {
     }
 
     to {
+        opacity: 1;
         border-radius: var(--size);
         border-width: 3px;
 
@@ -235,7 +242,7 @@ dialog > .close {
     to {
         opacity: 0;
         /* border-radius: 5px; */
-        border-width: 0;
+        /* border-width: 0; */
         /* filter: blur(3px); */
     }
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -1,0 +1,34 @@
+dialog {
+    position: relative;
+    width: 80%;
+    height: 80%;
+    overflow: auto;
+    padding: 1em;
+    box-sizing: border-box;
+    border-radius: var(--corner, 20px);
+
+    color: inherit;
+    background-color: #808080CC;
+}
+
+dialog::backdrop {
+    background-color: #000000CC;
+    backdrop-filter: blur(2px);
+}
+
+/* TODO: remove defaults from dialog and explicitly style .modal */
+dialog > .modal {
+    position: absolute;
+    inset: 0;
+    height: fit-content;
+    padding: 2rem;
+    background-color: hsl(0, 0%, var(--bg-value, 50%));
+}
+
+dialog > .close {
+    position: sticky;
+    top: 0.5em;
+    right: 0.5em;
+    display: block;
+    margin-left: auto;
+}

--- a/components/modal.css
+++ b/components/modal.css
@@ -36,6 +36,8 @@ dialog > .close {
 
 /* Organize modal */
 .overview {
+    position: relative;
+    overflow: hidden;
     display: grid;
     gap: 1em;
 }
@@ -46,6 +48,15 @@ dialog > .close {
     border: 2px solid #808080;
 }
 
+.org-wrapper > p {
+    margin-bottom: 0.5em;
+    cursor: pointer;
+}
+
+.org-wrapper > p[contenteditable="true"] {
+    cursor: text;
+}
+
 .org-palette {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(16ch, 1fr));
@@ -54,6 +65,7 @@ dialog > .close {
 .org-swatch {
     padding: 10px;
     padding-left: 1em;
+    position: relative;
     overflow: hidden;
     text-wrap: nowrap;
     text-overflow: ellipsis;
@@ -76,4 +88,26 @@ dialog > .close {
 
 .org-swatch[contenteditable="true"] {
     cursor: text;
+}
+
+.drag-handle {
+    /* font-weight: bolder; */
+    font-size: 150%;
+    position: absolute;
+    top: 50%;
+    left: 0.25rem;
+    translate: 0 -50%;
+
+    cursor: grab;
+}
+
+.bucket {
+    padding: 2em;
+    border: 2px solid white;
+    translate: -50% -50%;
+    position: absolute;
+    border-radius: 50%;
+
+    cursor: grabbing;
+    pointer-events: none;
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -58,15 +58,22 @@ dialog > .close {
     text-wrap: nowrap;
     text-overflow: ellipsis;
     box-sizing: border-box;
+
+    cursor: pointer;
 }
 
 .org-swatch:focus {
     overflow: visible;
     width: fit-content;
     min-width: 100%;
-
     z-index: 1;
     position: relative;
     translate: -50%;
     left: 50%;
+
+    border-radius: 5px;
+}
+
+.org-swatch[contenteditable="true"] {
+    cursor: text;
 }

--- a/components/modal.css
+++ b/components/modal.css
@@ -53,8 +53,20 @@ dialog > .close {
 
 .org-swatch {
     padding: 10px;
+    padding-left: 1em;
     overflow: hidden;
     text-wrap: nowrap;
     text-overflow: ellipsis;
     box-sizing: border-box;
+}
+
+.org-swatch:focus {
+    overflow: visible;
+    width: fit-content;
+    min-width: 100%;
+
+    z-index: 1;
+    position: relative;
+    translate: -50%;
+    left: 50%;
 }

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -76,34 +76,57 @@ export class OrganizeModal {
 
 function editableContent(element, property) {
     element
-        .attr('contenteditable', 'true')
+        .attr('contenteditable', 'false')
         .attr('spellcheck', 'false')
+        .attr('tabindex', '0')
         .text(d => d[property])
         // .on('input', function (event) {
         //     console.log('input', event);
         // })
+        // .on('click', function (event) {
+        //     console.log('Click');
+        //     event.preventDefault();
+        //     d3.select(this).attr('contenteditable', 'true');
+        // })
+        .on('dblclick', function (event) {
+            console.log('DoubleClick');
+            event.preventDefault();
+            d3.select(this).attr('contenteditable', 'true');
+        })
         .on('keydown', function (event) {
             // console.log(event);
-            if (event.code === 'Enter') {
-                event.preventDefault();
+            if (event.code !== 'Enter') return;
+            console.log('Enter', this);
+            event.preventDefault();
+
+            const selection = d3.select(this);
+            const editable = selection.attr('contenteditable').toLowerCase() === 'true';
+
+            if (editable) {
+                selection.attr('contenteditable', 'false');
                 this.blur();
+            } else {
+                selection.attr('contenteditable', 'true');
             }
         })
         .on('focus', function () {
             console.log('focus', this);
-
+            /* 
             const selection = d3.select(this);
             const datum = selection.datum();
             const text = selection.text();
             console.log({ datum, text });
+             */
         })
         .on('blur', function () {
             console.log('blur', this);
 
             const selection = d3.select(this);
+            selection.attr('contenteditable', 'false');
+
             const datum = selection.datum();
             const text = selection.text();
             datum[property] = text;
-            console.log({ datum, text });
+            // console.log({ datum, text });
         });
 }

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import './modal.css';
+import { Swatch, Palette } from '../classes';
 
 export class OrganizeModal {
     static { }
@@ -36,7 +37,9 @@ export class OrganizeModal {
         this.openButton.on('click', () => this.open());
 
         this.modal = d3.select(dialog).select('.modal');
-        this.overview = this.modal.select('.overview');
+        this.overview = this.modal.select('.overview')
+            .call(attachDragHandle)
+            .call(dragger, this);
 
         this.callback = callback || (() => { });
     }
@@ -68,6 +71,29 @@ export class OrganizeModal {
         console.log('Done organizing');
 
         this.overview.selectAll('div').remove();
+
+        this.callback();
+    }
+
+    update() {
+        this.overview.selectAll('div').remove();
+
+        this.overview.selectAll('div')
+            .data(Palette.collection)
+            .join('div')
+            .classed('org-wrapper', true)
+            .call(wrapper => wrapper
+                .append('p')
+                .call(editableContent, 'name')
+            )
+            .append('div')
+            .classed('org-palette', true)
+            .selectAll('div')
+            .data(d => d.swatches)
+            .join('div')
+            .classed('org-swatch', true)
+            .style('background-color', d => d.color.formatHex())
+            .call(editableContent, 'name');
 
         this.callback();
     }
@@ -110,7 +136,7 @@ function editableContent(element, property) {
             }
         })
         .on('focus', function () {
-            console.log('focus', this);
+            // console.log('focus', this);
             /* 
             const selection = d3.select(this);
             const datum = selection.datum();
@@ -119,7 +145,7 @@ function editableContent(element, property) {
              */
         })
         .on('blur', function () {
-            console.log('blur', this);
+            // console.log('blur', this);
 
             const selection = d3.select(this);
             selection.attr('contenteditable', 'false');
@@ -129,4 +155,110 @@ function editableContent(element, property) {
             datum[property] = text;
             // console.log({ datum, text });
         });
+}
+
+let dragActive = false;
+let dropZone = null;
+
+const dragHandle = d3.create('div')
+    .classed('drag-handle', true)
+    .text('⋮')
+    .node();
+
+/** @param {d3.Selection} element */
+function attachDragHandle(element) {
+    element
+        .on('mouseover', function (event) {
+            // console.log(event);
+            // const targetCondition = event.target.getAttribute('contenteditable') === 'false';
+            const targetCondition = event.target.matches('.org-swatch');
+            if (targetCondition) {
+                if (dragActive) {
+                    dropZone = event.target;
+                } else {
+                    event.target.append(dragHandle)
+                }
+            } else {
+                dragHandle.remove();
+                dropZone = null;
+            }
+        })
+}
+
+function dragger(overview, organizeModal) {
+    /** @type {d3.Selection<HTMLDivElement, Swatch>} */
+    let dragged = null;
+
+    const bucket = d3.create('div')
+        .classed('bucket', true)
+
+    /** @param {d3.D3DragEvent} event */
+    function dragstart(event) {
+        console.log('dragStart', event);
+
+        dragActive = true;
+
+        dragged = d3.select(event.sourceEvent.target.parentNode)
+            .style('display', 'none');
+
+        const [x, y] = d3.pointer(event, this);
+
+        this.append(bucket
+            .style('left', x + 'px')
+            .style('top', y + 'px')
+            .style('background-color', dragged.style('background-color'))
+            .node());
+    }
+
+    /** @param {d3.D3DragEvent} event */
+    function dragging(event) {
+        // console.log(event);
+        const [x, y] = d3.pointer(event, this);
+
+        bucket
+            .style('left', x + 'px')
+            .style('top', y + 'px')
+            .style('background-color', dragged.style('background-color'));
+    }
+
+    /** @param {d3.D3DragEvent} event */
+    function dragend(event) {
+        console.log('dragEnd', event);
+
+        dragged.style('display', null);
+        bucket.remove();
+
+        if (dropZone) {
+            const dragSwatch = dragged.datum();
+
+            /** @type {Swatch} */
+            const dropSwatch = d3.select(dropZone).datum();
+            dragSwatch.palette.swatches.splice(dragSwatch.getIndex(), 1);
+            dragSwatch.palette = dropSwatch.palette;
+            const index = dropSwatch.getIndex();
+            dropSwatch.palette.swatches.splice(index, 0, dragSwatch);
+
+            organizeModal.update();
+        }
+
+        dragged = null;
+
+        dragActive = false;
+    }
+
+    return d3.drag()
+        .filter(function (event) {
+            // console.log(event);
+
+            return (
+                !event.ctrlKey &&
+                !event.button &&
+                event.originalTarget === dragHandle
+                // event.originalTarget.getAttribute('contenteditable') === 'false'
+            );
+        })
+        .on('start', dragstart)
+        .on('drag', dragging)
+        .on('end', dragend)
+        (overview);
 }

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -8,8 +8,14 @@ export class OrganizeModal {
     dialog;
     /** @type {d3.Selection} */
     openButton;
+    /** @type {d3.Selection} */
+    modal;
+    /** @type {d3.Selection} */
+    overview;
+    /** @type {Function} */
+    callback;
 
-    constructor(dialog, openButton) {
+    constructor(dialog, openButton, callback) {
         this.dialog = dialog instanceof HTMLDialogElement ?
             dialog : document.querySelector(dialog);
 
@@ -30,6 +36,8 @@ export class OrganizeModal {
 
         this.modal = d3.select(dialog).select('.modal');
         this.overview = this.modal.select('.overview');
+
+        this.callback = callback || (() => {});
     }
 
     open() {
@@ -38,12 +46,20 @@ export class OrganizeModal {
         this.overview.selectAll('div')
             .data(Palette.collection)
             .join('div')
-            .text(d => d.name)
-            .append('dl')
-            .selectAll('dd')
+            .classed('org-wrapper', true)
+            .call(wrapper => wrapper
+                .append('p')
+                .text(d => d.name)
+                // TODO: text Content to datum name
+            )
+            .append('div')
+            .classed('org-palette', true)
+            .selectAll('div')
             .data(d => d.swatches)
-            .join('dd')
-            .text(d => d.name);
+            .join('div')
+            .classed('org-swatch', true)
+            .style('background-color', d => d.color.formatHex())
+            .text(d => d.name)
 
         this.dialog.showModal();
     }
@@ -51,8 +67,9 @@ export class OrganizeModal {
     close() {
         console.log('Done organizing');
 
-        // TODO: update main grid displays
-
+        this.overview.selectAll('div').remove();
         this.dialog.close();
+
+        this.callback();
     }
 }

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -20,15 +20,16 @@ export class OrganizeModal {
             dialog : document.querySelector(dialog);
 
         d3.select(this.dialog)
+            .on('close', () => this.close())
             .on('mouseup', (event) => {
                 // console.log(event);
                 if (event.target !== this.dialog) return;
-                this.close();
+                this.dialog.close();
             })
             .append('button')
             .classed('close', true)
             .text('✖')
-            .on('mouseup', () => this.close());
+            .on('mouseup', () => this.dialog.close());
 
         this.openButton = openButton instanceof d3.selection ?
             openButton : d3.select(openButton);
@@ -67,7 +68,6 @@ export class OrganizeModal {
         console.log('Done organizing');
 
         this.overview.selectAll('div').remove();
-        this.dialog.close();
 
         this.callback();
     }

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -1,0 +1,58 @@
+import * as d3 from 'd3';
+import './modal.css';
+
+export class OrganizeModal {
+    static { }
+
+    /** @type {HTMLDialogElement} */
+    dialog;
+    /** @type {d3.Selection} */
+    openButton;
+
+    constructor(dialog, openButton) {
+        this.dialog = dialog instanceof HTMLDialogElement ?
+            dialog : document.querySelector(dialog);
+
+        d3.select(this.dialog)
+            .on('click', (event) => {
+                // console.log(event);
+                if (event.target !== this.dialog) return;
+                this.close();
+            })
+            .append('button')
+            .classed('close', true)
+            .text('✖')
+            .on('click', () => this.close());
+
+        this.openButton = openButton instanceof d3.selection ?
+            openButton : d3.select(openButton);
+        this.openButton.on('click', () => this.open());
+
+        this.modal = d3.select(dialog).select('.modal');
+        this.overview = this.modal.select('.overview');
+    }
+
+    open() {
+        console.log('Organize');
+
+        this.overview.selectAll('div')
+            .data(Palette.collection)
+            .join('div')
+            .text(d => d.name)
+            .append('dl')
+            .selectAll('dd')
+            .data(d => d.swatches)
+            .join('dd')
+            .text(d => d.name);
+
+        this.dialog.showModal();
+    }
+
+    close() {
+        console.log('Done organizing');
+
+        // TODO: update main grid displays
+
+        this.dialog.close();
+    }
+}

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -200,7 +200,7 @@ function dragger(overview, organizeModal) {
         .on('mouseover', function (event) {
             /** @type {HTMLDivElement} */
             const hovered = event.target;
-            console.log(hovered.className, d3.now());
+            // console.log(hovered.className, d3.now());
 
             if (!dragActive) {
                 if (hovered.matches('.org-swatch')) {
@@ -279,6 +279,8 @@ function dragger(overview, organizeModal) {
             .style('top', y + 'px')
             .style('background-color', dragged.style('background-color'))
             .node());
+
+        organizeModal.modal.classed('drag-active', true);
     }
 
     /** @param {d3.D3DragEvent} event */
@@ -316,6 +318,8 @@ function dragger(overview, organizeModal) {
         }
 
         swatchPlaceholder.remove();
+
+        organizeModal.modal.classed('drag-active', false);
 
         dragged = null;
 

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -13,6 +13,8 @@ export class OrganizeModal {
     modal;
     /** @type {d3.Selection} */
     overview;
+    /** @type {Map<Swatch,HTMLDivElement>} */
+    swatchMap;
     /** @type {Function} */
     callback;
 
@@ -40,6 +42,8 @@ export class OrganizeModal {
         this.overview = this.modal.select('.overview')
             .call(dragger, this);
 
+        this.swatchMap = new Map();
+
         this.callback = callback || (() => { });
     }
 
@@ -47,7 +51,7 @@ export class OrganizeModal {
         console.log('Organize');
 
         this.overview.selectAll('div')
-            .data(Palette.collection)
+            .data(Palette.collection, d => d.name)
             .join('div')
             .classed('org-wrapper', true)
             .call(wrapper => wrapper
@@ -57,9 +61,11 @@ export class OrganizeModal {
             .append('div')
             .classed('org-palette', true)
             .selectAll('div')
-            .data(d => d.swatches)
+            .data(d => d.swatches, d => d.name)
             .join('div')
+            .each((d, i, g) => this.swatchMap.set(d, g[i]))
             .classed('org-swatch', true)
+            .style('animation', 'none')
             .style('background-color', d => d.color.formatHex())
             .call(editableContent, 'name');
 
@@ -78,7 +84,7 @@ export class OrganizeModal {
         this.overview.selectAll('div').remove();
 
         this.overview.selectAll('div')
-            .data(Palette.collection)
+            .data(Palette.collection, d => d.name)
             .join('div')
             .classed('org-wrapper', true)
             .call(wrapper => wrapper
@@ -88,9 +94,11 @@ export class OrganizeModal {
             .append('div')
             .classed('org-palette', true)
             .selectAll('div')
-            .data(d => d.swatches)
+            .data(d => d.swatches, d => d.name)
             .join('div')
+            .each((d, i, g) => this.swatchMap.set(d, g[i]))
             .classed('org-swatch', true)
+            .style('animation', 'none')
             .style('background-color', d => d.color.formatHex())
             .call(editableContent, 'name');
 
@@ -343,9 +351,9 @@ function dragger(overview, organizeModal) {
         const h = childBBox.height;
         // console.log({ child, x, y, w, h });
 
+        let dragSwatch;
+        
         if (drop.active) {
-
-            let dragSwatch;
             if (drag.clone) {
                 const name = drag.swatch.name;
                 const color = drag.swatch.color.copy();
@@ -366,6 +374,15 @@ function dragger(overview, organizeModal) {
 
             organizeModal.update();
         }
+
+        // focus on swatch preview
+        if (!dragSwatch) dragSwatch = drag.swatch;
+        const preview = organizeModal.swatchMap.get(dragSwatch);
+        console.log(preview);
+        preview.focus();
+        preview.style.animation = 'none';
+        preview.offsetHeight;
+        preview.style.animation = null;
 
         this.append(bucket
             .classed('focus', false)

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -128,7 +128,7 @@ function editableContent(element, property) {
         })
         .on('keydown', function (event) {
             // console.log(event);
-            if (event.code !== 'Enter') return;
+            if (event.key !== 'Enter') return;
             console.log('Enter', this);
             event.preventDefault();
 
@@ -250,7 +250,11 @@ function dragger(overview, organizeModal) {
                     if (swatch === swatch.palette.swatches.at(-1)) {
                         hovered.parentElement.appendChild(swatchPlaceholder);
                     } else {
-                        drop.swatch = drop.palette.swatches[swatch.getIndex() + 1];
+                        const dropSwatchCandidate = drop.palette.swatches[swatch.getIndex() + 1];
+
+                        drag.swatch === dropSwatchCandidate ?
+                            drop.active = false :
+                            drop.swatch = dropSwatchCandidate;
 
                         hovered.parentElement
                             .insertBefore(swatchPlaceholder, hovered.nextElementSibling);
@@ -305,6 +309,13 @@ function dragger(overview, organizeModal) {
 
         this.append(bucket
             .classed('unfocus', false)
+            .each((d, i, g) => {
+                const buck = g[i];
+                buck.style.animation = 'none';
+                buck.offsetHeight; /* trigger reflow */
+                buck.style.animation = null;
+                // buck.focus();
+            })
             .classed('focus', true)
             .style('--left', left + 'px')
             .style('--top', top + 'px')
@@ -315,11 +326,12 @@ function dragger(overview, organizeModal) {
             .style('background-color', drag.element.style('background-color'))
             .node());
 
+        dragHandle.remove();
+
         if (event.sourceEvent.altKey) {
             drag.clone = true;
             // drag.element.node().blur();
             element.blur();
-            dragHandle.remove();
         } else {
             drag.element.style('display', 'none');
         }
@@ -352,7 +364,7 @@ function dragger(overview, organizeModal) {
         // console.log({ child, x, y, w, h });
 
         let dragSwatch;
-        
+
         if (drop.active) {
             if (drag.clone) {
                 const name = drag.swatch.name;
@@ -386,6 +398,12 @@ function dragger(overview, organizeModal) {
 
         this.append(bucket
             .classed('focus', false)
+            .each((d, i, g) => {
+                const buck = g[i];
+                buck.style.animation = 'none';
+                buck.offsetHeight; /* trigger reflow */
+                buck.style.animation = null;
+            })
             .classed('unfocus', true)
             .style('--x', x + 'px')
             .style('--y', y + 'px')
@@ -410,7 +428,7 @@ function dragger(overview, organizeModal) {
             return (
                 !event.ctrlKey &&
                 !event.button &&
-                event.originalTarget === dragHandle
+                event.srcElement === dragHandle
             );
         })
         .on('start', dragstart)

--- a/components/organize-modal.js
+++ b/components/organize-modal.js
@@ -20,7 +20,7 @@ export class OrganizeModal {
             dialog : document.querySelector(dialog);
 
         d3.select(this.dialog)
-            .on('click', (event) => {
+            .on('mouseup', (event) => {
                 // console.log(event);
                 if (event.target !== this.dialog) return;
                 this.close();
@@ -28,7 +28,7 @@ export class OrganizeModal {
             .append('button')
             .classed('close', true)
             .text('✖')
-            .on('click', () => this.close());
+            .on('mouseup', () => this.close());
 
         this.openButton = openButton instanceof d3.selection ?
             openButton : d3.select(openButton);
@@ -37,7 +37,7 @@ export class OrganizeModal {
         this.modal = d3.select(dialog).select('.modal');
         this.overview = this.modal.select('.overview');
 
-        this.callback = callback || (() => {});
+        this.callback = callback || (() => { });
     }
 
     open() {
@@ -49,8 +49,7 @@ export class OrganizeModal {
             .classed('org-wrapper', true)
             .call(wrapper => wrapper
                 .append('p')
-                .text(d => d.name)
-                // TODO: text Content to datum name
+                .call(editableContent, 'name')
             )
             .append('div')
             .classed('org-palette', true)
@@ -59,7 +58,7 @@ export class OrganizeModal {
             .join('div')
             .classed('org-swatch', true)
             .style('background-color', d => d.color.formatHex())
-            .text(d => d.name)
+            .call(editableContent, 'name');
 
         this.dialog.showModal();
     }
@@ -72,4 +71,39 @@ export class OrganizeModal {
 
         this.callback();
     }
+}
+
+
+function editableContent(element, property) {
+    element
+        .attr('contenteditable', 'true')
+        .attr('spellcheck', 'false')
+        .text(d => d[property])
+        // .on('input', function (event) {
+        //     console.log('input', event);
+        // })
+        .on('keydown', function (event) {
+            // console.log(event);
+            if (event.code === 'Enter') {
+                event.preventDefault();
+                this.blur();
+            }
+        })
+        .on('focus', function () {
+            console.log('focus', this);
+
+            const selection = d3.select(this);
+            const datum = selection.datum();
+            const text = selection.text();
+            console.log({ datum, text });
+        })
+        .on('blur', function () {
+            console.log('blur', this);
+
+            const selection = d3.select(this);
+            const datum = selection.datum();
+            const text = selection.text();
+            datum[property] = text;
+            console.log({ datum, text });
+        });
 }

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
           <button id="palette-rename">Rename</button>
           <button id="palette-delete">Delete</button>
           <hr width="100%">
-          <button disabled>Organize</button>
+          <button id="palette-organize">Organize</button>
         </div>
       </div>
 
@@ -162,6 +162,16 @@
     </div>
 
   </div>
+
+  <dialog id="organize-modal">
+    <div class="modal">
+
+      <h3>Your palettes</h3>
+
+      <div class="overview"></div>
+
+    </div>
+  </dialog>
 
 </body>
 

--- a/main.js
+++ b/main.js
@@ -644,6 +644,9 @@ const organizeModal = new OrganizeModal(
     '#organize-modal',
     '#palette-organize',
     () => {
+        // save palettes
+        window.localStorage.setItem(STRING.customPalettes, Palette.serialize())
+
         plantDots();
         PalettePreview.display();
 

--- a/main.js
+++ b/main.js
@@ -3,7 +3,8 @@ import './style.css';
 import './components/corner-fold-toggle.css';
 import * as d3 from 'd3';
 import { Swatch, Palette } from './classes';
-import { HueWheel } from './components/hue-range-widget'
+import { HueWheel } from './components/hue-range-widget';
+import { OrganizeModal } from './components/organize-modal';
 
 
 /* 
@@ -612,6 +613,10 @@ function deletePalette() {
         createNewPalette(STRING.defaultPaletteName);
     }
 };
+
+// dialog
+const organizeModal = new OrganizeModal('#organize-modal', '#palette-organize');
+
 
 /* 
  * MARK: Custom colors

--- a/main.js
+++ b/main.js
@@ -614,6 +614,31 @@ function deletePalette() {
     }
 };
 
+function updatePalettesOptions() {
+    customSelect.selectAll('option:not(:last-of-type)').remove();
+
+    for (let palette of Palette.collection) {
+        customSelect.insert('option', 'hr')
+            .datum(palette)
+            .text(d => d.name);
+    }
+
+    const index = Palette.chosenIndex;
+    customSelect.node().selectedIndex = index;
+
+    /* 
+    customSelect.selectAll('option:not(:last-of-type)')
+        .data(Palette.collection)
+        .join(
+            enter => enter
+                .insert('option', 'hr')
+                .text(d => d.name),
+            update => update.text(d => d.name),
+            exit => exit.remove()
+        );
+    */
+}
+
 // dialog
 const organizeModal = new OrganizeModal(
     '#organize-modal',
@@ -621,6 +646,15 @@ const organizeModal = new OrganizeModal(
     () => {
         plantDots();
         PalettePreview.display();
+
+        // update palette names in #custom-palette dropdown
+        updatePalettesOptions()
+
+        // update chosen swatch name in #color-name
+        const chosenSwatch = chosen.swatch;
+        if (chosenSwatch) {
+            document.querySelector('#color-name').value = chosenSwatch.name;
+        }
     }
 );
 
@@ -834,7 +868,8 @@ class PalettePreview {
                         this.minus.node().remove();
                         this.handle.node().remove();
                     }),
-                update => update,
+                update => update
+                    .attr('title', d => d.name),
                 exit => exit
                     .each((d, i, g) => {
                         colorMap.get(d.color).preview = null;
@@ -1159,12 +1194,14 @@ function removeSwatch(swatch) {
     // console.log(parsedPalettes);
 
     // create
+    updatePalettesOptions();
+    /* 
     for (let palette of parsedPalettes) {
         customSelect.insert('option', 'hr')
             .datum(palette)
             .text(d => d.name);
     }
-
+     */
     choosePalette(0);
 })();
 

--- a/main.js
+++ b/main.js
@@ -615,7 +615,14 @@ function deletePalette() {
 };
 
 // dialog
-const organizeModal = new OrganizeModal('#organize-modal', '#palette-organize');
+const organizeModal = new OrganizeModal(
+    '#organize-modal',
+    '#palette-organize',
+    () => {
+        plantDots();
+        PalettePreview.display();
+    }
+);
 
 
 /* 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "huebism",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "huebism",
   "private": false,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "huebism",
   "private": false,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "huebism",
   "private": false,
-  "version": "0.1.5",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Users can now easily reorganize their palettes by dragging the swatches around.